### PR TITLE
Add poppler-utils package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     python-cups python-dbus python-openssl python-libxml2 xfonts-base \
     xfonts-75dpi npm git postgresql-client wget libpq-dev libjpeg8-dev libldap2-dev \
     libffi-dev vim telnet ghostscript && \
+    poppler-utils && \
     npm install -g less less-plugin-clean-css && \
     ln -sf /usr/bin/nodejs /usr/bin/node && \
     apt-get clean


### PR DESCRIPTION
It allows to solve `Failed attempt to execute pdftotext. This program is necessary to index the file /tmp/tmp....`